### PR TITLE
send transaction support

### DIFF
--- a/flow/config.js
+++ b/flow/config.js
@@ -1,8 +1,24 @@
 import { config } from "@onflow/fcl";
 
-config({
-  "app.detail.title": "Flow Next.js Quick Start",
-  "accessNode.api": process.env.NEXT_PUBLIC_ACCESS_NODE_API,
-  "discovery.wallet": process.env.NEXT_PUBLIC_DISCOVERY_WALLET,
-  "0xProfile": process.env.NEXT_PUBLIC_CONTRACT_PROFILE, // The account address where the smart contract lives
-})
+const title = "Transaction and Script Builder"
+const testnetConfig = {
+  "app.detail.title": title,
+  "accessNode.api": 'https://access-testnet.onflow.org',
+  "discovery.wallet": 'https://fcl-discovery.onflow.org/testnet/authn'
+}
+
+const mainnetConfig = {
+  "app.detail.title": title,
+  "accessNode.api": "https://access-mainnet-beta.onflow.org",
+  "discovery.wallet": "https://fcl-discovery.onflow.org/authn",
+}
+
+config(testnetConfig)
+
+export const configureForNetwork = (network) => {
+  if(network === "testnet") {
+    config(testnetConfig)
+  } else if (network === "mainnet") {
+    config(mainnetConfig)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "monaco-editor": "^0.31.1",
     "monaco-editor-webpack-plugin": "^7.0.1",
     "monaco-languageclient": "^0.18.1",
-    "next": "12.0.7",
+    "next": "^12.0.7",
     "next-transpile-modules": "^9.0.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,8 +2,14 @@ import "@picocss/pico";
 import "../styles/globals.css";
 import Link from "next/link";
 import TransactionProvider from "../contexts/TransactionContext";
+import { useEffect } from "react";
 
 function MyApp({ Component, pageProps }) {
+
+  useEffect(() => {
+    console.log({pageProps})
+  }, [pageProps]);
+
   return (
     <div>
       <nav className="container header">

--- a/pages/index.js
+++ b/pages/index.js
@@ -99,15 +99,6 @@ export default function Home() {
         </button>
         <button
           onClick={async () => {
-            /*
-              const { addressMap, args = [], signers = [] } = props;
-              const code = await logTemplate(addressMap);
-
-              reportMissing("arguments", args.length, 0, `log =>`);
-              reportMissing("signers", signers.length, 1, `log =>`);
-
-              return sendTransaction({code, ...props})
-             */
             console.log(await txn())
           }}
         >


### PR DESCRIPTION
Adds the ability to send transactions. If you switch networks, fcl will log you out and switch to a new config. You are only prompted to login if you haven't already when you click the `Send Transaction` button